### PR TITLE
chore: switch to Sonatype Central Portal deployment (2.1)

### DIFF
--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -3,5 +3,6 @@ buildMavenAndDeployToMavenCentral([
   jdk:8,
   licenseCheck:true,
   mvn:3.3,
+  mvnReleaseProfiles:'sonatype-oss-release',
   publishZipArtifactToCamundaOrg:true
 ])

--- a/.ci.cambpm
+++ b/.ci.cambpm
@@ -1,2 +1,7 @@
 @Library("camunda-ci") _
-buildMavenAndDeployToMavenCentral([jdk:8, licenseCheck:true, publishZipArtifactToCamundaOrg:true])
+buildMavenAndDeployToMavenCentral([
+  jdk:8,
+  licenseCheck:true,
+  mvn:3.3,
+  publishZipArtifactToCamundaOrg:true
+])

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.camunda</groupId>
     <artifactId>camunda-bpm-release-parent</artifactId>
-    <version>2.2.6</version>
+    <version>2.2.8</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
     <relativePath />
   </parent>


### PR DESCRIPTION
Related to https://github.com/camunda/team-infrastructure/issues/833.

Backporting https://github.com/camunda/camunda-template-engines-jsr223/pull/38 to `2.1` branch.

Additionally,  to make nexus-staging-maven-plugin +  ossrh-staging-api.central.sonatype.com work (new central-publishing-maven-plugin required maven 3.8+):
- bump maven version to 3.3
- fallback to the deprecated sonatype-oss-release profile

Test: https://stage.ci.cambpm.camunda.cloud/job/camunda-github-org/job/camunda-template-engines-jsr223/view/change-requests/job/PR-39/2/console